### PR TITLE
Workaround for telnetlib removal in Python 3.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,13 @@ pip install -r requirements.txt
 
 Or install the required libraries manually.
 
+### Python 3.13 and later
+
+The standard library's ``telnetlib`` module was removed in Python 3.13.
+This repository bundles a tiny ``simple_telnet`` module that provides the
+subset of functionality required by the exploit scripts, so no additional
+dependencies are needed on newer Python versions.
+
 ## Usage
 
 Connect to your hotspot's network via USB tethering (recommended) or WiFi, then run:

--- a/simple_telnet.py
+++ b/simple_telnet.py
@@ -1,0 +1,134 @@
+"""Simple Telnet client for environments without telnetlib.
+
+This module implements a minimal subset of the standard library's
+``telnetlib`` interface required by the TMOHS1 exploit utilities. It is
+*not* a full featured Telnet implementation, but provides the small
+feature set used by ``utils.py``:
+
+* open(host, port, timeout)
+* write(data)
+* read_until(expected, timeout)
+* read_very_eager()
+* mt_interact() for an interactive shell
+
+The code relies only on the standard ``socket`` and ``select`` modules
+so it works on Python versions where ``telnetlib`` has been removed.
+"""
+
+from __future__ import annotations
+
+import select
+import socket
+import sys
+import threading
+import time
+from typing import Optional
+
+# Telnet command bytes used for keepalive messages
+IAC = b"\xff"  # Interpret As Command
+NOP = b"\xf1"  # No Operation
+
+
+class Telnet:
+    """Minimal telnet client with a subset of ``telnetlib``'s API."""
+
+    def __init__(
+        self,
+        host: Optional[str] = None,
+        port: int = 23,
+        timeout: Optional[float] = socket._GLOBAL_DEFAULT_TIMEOUT,
+    ) -> None:
+        self.sock: Optional[socket.socket] = None
+        if host:
+            self.open(host, port, timeout)
+
+    # Connection handling -------------------------------------------------
+    def open(
+        self,
+        host: str,
+        port: int = 23,
+        timeout: Optional[float] = socket._GLOBAL_DEFAULT_TIMEOUT,
+    ) -> None:
+        """Open a connection to *host*:*port*."""
+        self.sock = socket.create_connection((host, port), timeout)
+        self.sock.setblocking(False)
+
+    def close(self) -> None:
+        if self.sock:
+            try:
+                self.sock.close()
+            finally:
+                self.sock = None
+
+    # Sending and receiving -----------------------------------------------
+    def write(self, buffer: bytes) -> None:
+        if self.sock is None:
+            raise OSError("Socket is not connected")
+        self.sock.sendall(buffer)
+
+    def _read(self, timeout: Optional[float]) -> bytes:
+        if self.sock is None:
+            raise OSError("Socket is not connected")
+        ready, _, _ = select.select([self.sock], [], [], timeout)
+        if not ready:
+            return b""
+        return self.sock.recv(4096)
+
+    def read_until(self, expected: bytes, timeout: Optional[float] = None) -> bytes:
+        """Read until *expected* bytes are seen or timeout expires."""
+        buf = b""
+        end = None if timeout is None else time.time() + timeout
+        while True:
+            remaining = None if end is None else max(0, end - time.time())
+            chunk = self._read(remaining)
+            if not chunk:
+                break
+            buf += chunk
+            if expected in buf:
+                break
+            if end is not None and time.time() >= end:
+                break
+        return buf
+
+    def read_very_eager(self) -> bytes:
+        """Read as much data as is readily available."""
+        buf = b""
+        while True:
+            chunk = self._read(0)
+            if not chunk:
+                break
+            buf += chunk
+        return buf
+
+    # Interactive shell ---------------------------------------------------
+    def mt_interact(self) -> None:
+        """Simple multithreaded interactive shell."""
+
+        def writer() -> None:
+            while True:
+                line = sys.stdin.readline()
+                if not line:
+                    break
+                self.write(line.encode())
+
+        def reader() -> None:
+            while True:
+                data = self.read_very_eager()
+                if data:
+                    try:
+                        sys.stdout.write(data.decode(errors="ignore"))
+                        sys.stdout.flush()
+                    except Exception:
+                        pass
+                time.sleep(0.1)
+
+        t = threading.Thread(target=reader, daemon=True)
+        t.start()
+        try:
+            writer()
+        except KeyboardInterrupt:
+            pass
+
+
+__all__ = ["Telnet", "IAC", "NOP"]
+

--- a/utils.py
+++ b/utils.py
@@ -11,11 +11,15 @@
 # -----------------------------------------------
 
 import time
-import telnetlib
 from getpass import getpass
 from ftplib import FTP
 import argparse
 import os
+
+# ``telnetlib`` was removed in Python 3.13.  To keep this project working on
+# newer interpreters we ship a very small subset of its functionality in
+# ``simple_telnet``.
+from simple_telnet import Telnet, IAC, NOP
 
 parser = argparse.ArgumentParser()
 parser.add_argument('-v', '--verbose',
@@ -25,9 +29,9 @@ parser.add_argument('-v', '--verbose',
 args = parser.parse_args()
 
 
-# TelnetConnection class adds some case-specific methods to the telnetlib.Telnet class
+# TelnetConnection class adds some case-specific methods to the Telnet class
 
-class TelnetConnection(telnetlib.Telnet):
+class TelnetConnection(Telnet):
     def __init__(self, host, wait):
         self.host = host
         self.wait = wait
@@ -68,9 +72,9 @@ class TelnetConnection(telnetlib.Telnet):
         try:
             if self.sock:
                 # we try 3 times for good luck, idk ask stackoverflow
-                self.sock.send(telnetlib.IAC + telnetlib.NOP)
-                self.sock.send(telnetlib.IAC + telnetlib.NOP)
-                self.sock.send(telnetlib.IAC + telnetlib.NOP)
+                self.sock.send(IAC + NOP)
+                self.sock.send(IAC + NOP)
+                self.sock.send(IAC + NOP)
                 return True
         except:
             return False


### PR DESCRIPTION
## Summary
- add `simple_telnet` module providing a tiny subset of the old telnetlib API
- update utilities to use `simple_telnet` when making telnet connections
- document telnetlib removal in README

## Testing
- `python -m py_compile rootScript.py utils.py simple_telnet.py`


------
https://chatgpt.com/codex/tasks/task_e_68993ea38590832799cc4c40db6ad511